### PR TITLE
Add FASTA streamer

### DIFF
--- a/src/fasta.mli
+++ b/src/fasta.mli
@@ -1,7 +1,16 @@
-type t = { name : string; sequence : string }
+type 'a chunk = Stop of 'a | Continue of 'a
 
-val clean_name : string -> string
-val clean_sequence : string list -> string
-val make_sequence : string -> t
-val get_sequences : string -> string list
-val parse_fasta : string -> t list
+module Chunk : sig
+  val value : 'a chunk -> 'a
+end
+
+module type FASTAStreamerConfig = sig
+  val filename : string
+  val chunk_size : int
+end
+
+module type S = sig
+  val next : unit -> string chunk
+end
+
+module FASTAStreamer (_ : FASTAStreamerConfig) : S

--- a/tests/dune
+++ b/tests/dune
@@ -1,7 +1,9 @@
 (test
  (name test_fasta)
  (modules test_fasta)
- (libraries core ounit2 fasta))
+ (libraries core ounit2 fasta)
+ (deps
+  (glob_files_rec ./fasta.test)))
 
 (test
  (name test_bigbwt)

--- a/tests/fasta.test
+++ b/tests/fasta.test
@@ -1,0 +1,4 @@
+>Sequence1 - metadata\n
+ACTGXMACTGXMACTGXMACTGX
+>Sequence2 - metadata\n
+ACTGXMACTGXMACTGXMACTGX

--- a/tests/test_fasta.ml
+++ b/tests/test_fasta.ml
@@ -1,52 +1,31 @@
-open Core
+(* open Core *)
 open OUnit2
 open Fasta
 
-let dummy_fasta =
-  ">Sequence1 - metadata\nACTGXM*\n>Sequence2 - metadata\nACTGXM\nACTGXM*"
+let test_small_chunk _ =
+  let module Config : FASTAStreamerConfig = struct
+    let filename = "./fasta.test"
+    let chunk_size = 10
+  end in
+  let module Streamer = FASTAStreamer (Config) in
+  assert_equal (Continue "$") @@ Streamer.next ();
+  assert_equal (Continue "") @@ Streamer.next ();
+  assert_equal (Continue "ACTG") @@ Streamer.next ()
 
-let test_get_sequences _ =
-  assert_equal
-    [
-      "Sequence1 - metadata\nACTGXM*\n"; "Sequence2 - metadata\nACTGXM\nACTGXM*";
-    ]
-  @@ get_sequences dummy_fasta
-
-let test_clean_name _ =
-  assert_equal "Sequence1" @@ clean_name "Sequence1 - metadata";
-  assert_equal "Sequence2" @@ clean_name "Sequence2 - metadata"
-
-let test_clean_sequence _ =
-  assert_equal "ACTG" @@ clean_sequence [ "ACTGXM*" ];
-  assert_equal "ACTGACTG" @@ clean_sequence [ "ACTGXM"; "ACTGXM*" ]
-
-let test_make_sequence _ =
-  assert_raises (Failure "Empty sequence") (fun () -> make_sequence "");
-  assert_raises (Failure "Invalid sequence") (fun () -> make_sequence "\n");
-  assert_raises (Failure "Invalid sequence") (fun () ->
-      make_sequence "Sequence1\n");
-  assert_equal { name = "Sequence1"; sequence = "ACTG" }
-  @@ make_sequence "Sequence1 - metadata\nACTGXM*\n";
-  assert_equal { name = "Sequence2"; sequence = "ACTGACTG" }
-  @@ make_sequence "Sequence2 - metadata\nACTGXM\nACTGXM*"
-
-let test_parse_fasta _ =
-  assert_equal
-    [
-      { name = "Sequence1"; sequence = "ACTG" };
-      { name = "Sequence2"; sequence = "ACTGACTG" };
-    ]
-  @@ (get_sequences dummy_fasta |> List.map ~f:make_sequence)
+let test_large_chunk _ =
+  let module Config : FASTAStreamerConfig = struct
+    let filename = "./fasta.test"
+    let chunk_size = 200
+  end in
+  let module Streamer = FASTAStreamer (Config) in
+  assert_equal (Stop "$ACTGACTGACTGACTG$ACTGACTGACTGACTG") @@ Streamer.next ()
 
 let parse_fasta_tests =
   "parse_fasta tests"
   >: test_list
        [
-         "test get_sequences" >:: test_get_sequences;
-         "test clea_name" >:: test_clean_name;
-         "test clean_sequence" >:: test_clean_sequence;
-         "test make_sequence" >:: test_make_sequence;
-         "test parse_fasta" >:: test_parse_fasta;
+         "test small chunk" >:: test_small_chunk;
+         "test large chunk" >:: test_large_chunk;
        ]
 
 let series = "FASTA tests" >::: [ parse_fasta_tests ]


### PR DESCRIPTION
Changing the logic of the FASTA parse to FASTA streamer, for example

```python
open Fasta

let module Config : FASTAStreamerConfig = struct
    let filename = "./fasta.test"
    let chunk_size = 200
  end
 let module Streamer = FASTAStreamer (Config)

Streamer.next ()
# outputs `Stop "$ACTGACTGACTGACTG$ACTGACTGACTGACTG"`
```